### PR TITLE
Added various possible camera models for the photometric and response calibration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,10 @@ include_directories(
 )
 
 
-add_executable(responseCalib src/main_responseCalib.cpp src/FOVUndistorter.cpp src/PhotometricUndistorter.cpp)
+add_executable(responseCalib src/main_responseCalib.cpp src/FOVUndistorter.cpp src/Undistorter.cpp src/PhotometricUndistorter.cpp)
 target_link_libraries(responseCalib ${OpenCV_LIBS} ${LIBZIP_LIBRARY})
 
-add_executable(playDataset src/main_playbackDataset.cpp src/FOVUndistorter.cpp src/PhotometricUndistorter.cpp)
+add_executable(playDataset src/main_playbackDataset.cpp src/FOVUndistorter.cpp src/Undistorter.cpp src/PhotometricUndistorter.cpp)
 target_link_libraries(playDataset ${OpenCV_LIBS} ${LIBZIP_LIBRARY})
 
 
@@ -40,7 +40,7 @@ SET(CMAKE_MODULE_PATH ${CMAKE_INSTALL_PREFIX}/lib/cmake/ )
 find_package(aruco)
 
 IF(aruco_FOUND)
-	add_executable(vignetteCalib src/main_vignetteCalib.cpp src/FOVUndistorter.cpp src/PhotometricUndistorter.cpp)
+	add_executable(vignetteCalib src/main_vignetteCalib.cpp src/FOVUndistorter.cpp src/Undistorter.cpp src/PhotometricUndistorter.cpp)
 	target_link_libraries(vignetteCalib ${OpenCV_LIBS} ${aruco_LIBS} ${LIBZIP_LIBRARY})
 ELSE()
 	message("================ aruco not found. not compiling vignetteCalib. ========================")

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-
+Update (AlbertoJaenal): the calibration accepts various camera model. The code was copied from [https://github.com/JakobEngel/dso](https://github.com/JakobEngel/dso) and reformed to fit.
 
 # Install
-
-Update (AlbertoJaenal): the calibration accepts various camera model. The code was copied from [https://github.com/JakobEngel/dso](https://github.com/JakobEngel/dso) and reformed to fit.
 
 #### 1. Install Eigen & OpenCV (if you don't have it):
     sudo apt-get install libeigen3-dev libopencv-dev
@@ -71,7 +69,7 @@ vignetteSmoothed.png is a slightly smoothed version, mainly to remove the black 
 **WARNING: requires a lot of Memory (16GB ram for 1000 input images)**! Can easily be changed at the cost of slightly slower runtime... you'll have to do that yourself though.
 
 
-##### Geometric Calibration File (from [https://github.com/JakobEngel/dso](https://github.com/JakobEngel/dso))
+##### Geometric Calibration File (from [https://github.com/JakobEngel/dso](https://github.com/JakobEngel/dso#geometric-calibration-file))
 
 
 ###### Calibration File for Pre-Rectified Images

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Install
 
+Update (AlbertoJaenal): the calibration accepts various camera model. The code was copied from [https://github.com/JakobEngel/dso](https://github.com/JakobEngel/dso) and reformed to fit.
+
 #### 1. Install Eigen & OpenCV (if you don't have it):
     sudo apt-get install libeigen3-dev libopencv-dev
 
@@ -68,6 +70,44 @@ outputs some intermediate results, and vignette.png (16-bit png) containing the 
 vignetteSmoothed.png is a slightly smoothed version, mainly to remove the black borders (pixels at the border are never observed). See code for details.
 **WARNING: requires a lot of Memory (16GB ram for 1000 input images)**! Can easily be changed at the cost of slightly slower runtime... you'll have to do that yourself though.
 
+
+##### Geometric Calibration File (from [https://github.com/JakobEngel/dso](https://github.com/JakobEngel/dso))
+
+
+###### Calibration File for Pre-Rectified Images
+
+    Pinhole fx fy cx cy 0
+    in_width in_height
+    "crop" / "full" / "none" / "fx fy cx cy 0"
+    out_width out_height
+
+###### Calibration File for FOV camera model:
+
+    FOV fx fy cx cy omega
+    in_width in_height
+    "crop" / "full" / "fx fy cx cy 0"
+    out_width out_height
+
+
+###### Calibration File for Radio-Tangential camera model
+
+    RadTan fx fy cx cy k1 k2 r1 r2
+    in_width in_height
+    "crop" / "full" / "fx fy cx cy 0"
+    out_width out_height
+
+
+###### Calibration File for Equidistant camera model
+
+    EquiDistant fx fy cx cy k1 k2 r1 r2
+    in_width in_height
+    "crop" / "full" / "fx fy cx cy 0"
+    out_width out_height
+
+
+(note: for backwards-compatibility, "Pinhole", "FOV" and "RadTan" can be omitted). See the respective
+`::distortCoordinates` implementation in  `Undistorter.cpp` for the exact corresponding projection function.
+Furthermore, it should be straight-forward to implement other camera models.
 
 
 # Usage: Matlab evaluation code

--- a/src/BenchmarkDatasetReader.h
+++ b/src/BenchmarkDatasetReader.h
@@ -35,7 +35,8 @@
 #include <algorithm>
 
 #include "opencv2/opencv.hpp"
-#include "FOVUndistorter.h"
+//#include "FOVUndistorter.h"
+#include "Undistorter.h"
 #include "PhotometricUndistorter.h"
 
 #include "zip.h"
@@ -132,7 +133,8 @@ public:
 
 
 		// create undistorter.
-		undistorter = new UndistorterFOV((path+"camera.txt").c_str());
+		//undistorter = new UndistorterFOV((path+"camera.txt").c_str());
+		undistorter = Undistort::getUndistorterForFile((path+"camera.txt").c_str());
 		photoUndistorter = new PhotometricUndistorter(path+"pcalib.txt", path+"vignette.png",undistorter->getInputDims()[0],undistorter->getInputDims()[1]);
 
 
@@ -156,7 +158,12 @@ public:
 
 	}
 
-	UndistorterFOV* getUndistorter()
+	/*UndistorterFOV* getUndistorter()
+	{
+		return undistorter;
+	}*/
+	
+	Undistort* getUndistorter()
 	{
 		return undistorter;
 	}
@@ -336,7 +343,8 @@ private:
 
 
 	// internal structures.
-	UndistorterFOV* undistorter;
+	//UndistorterFOV* undistorter;
+	Undistort* undistorter;
 	PhotometricUndistorter* photoUndistorter;
 	zip_t* ziparchive;
 	char* databuffer;

--- a/src/Undistorter.cpp
+++ b/src/Undistorter.cpp
@@ -1,0 +1,856 @@
+/**
+* This file is part of DSO.
+* 
+* Copyright 2016 Technical University of Munich and Intel.
+* Developed by Jakob Engel <engelj at in dot tum dot de>,
+* for more information see <http://vision.in.tum.de/dso>.
+* If you use this code, please cite the respective publications as
+* listed on the above website.
+*
+* DSO is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* DSO is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with DSO. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+
+
+#include <sstream>
+#include <fstream>
+#include <iostream>
+
+#include <Eigen/Core>
+#include <iterator>
+#include "Undistorter.h"
+
+
+
+Undistort::~Undistort()
+{
+	if(remapX != 0) delete[] remapX;
+	if(remapY != 0) delete[] remapY;
+}
+
+Undistort* Undistort::getUndistorterForFile(const char* configFilename)
+{
+	printf("Reading Calibration from file %s", configFilename);
+
+	// read parameters
+	std::ifstream infile(configFilename);
+	if(!infile.good())
+	{
+		printf("Failed to read camera calibration (invalid format?)\nCalibration file: %s\n", configFilename);
+		return 0;
+	}
+
+	printf(" ... found!\n");
+	std::string l1;
+	std::getline(infile,l1);
+
+	float ic[10];
+
+	Undistort* u;
+
+    // for backwards-compatibility: Use RadTan model for 8 parameters.
+	if(std::sscanf(l1.c_str(), "%f %f %f %f %f %f %f %f",
+			&ic[0], &ic[1], &ic[2], &ic[3],
+			&ic[4], &ic[5], &ic[6], &ic[7]) == 8)
+	{
+        printf("found RadTan (OpenCV) camera model, building rectifier.\n");
+        u = new UndistortRadTan(configFilename, true);
+		if(!u->isValid()) {delete u; return 0; }
+    }
+
+    // for backwards-compatibility: Use Pinhole / FoV model for 5 parameter.
+    else if(std::sscanf(l1.c_str(), "%f %f %f %f %f",
+			&ic[0], &ic[1], &ic[2], &ic[3], &ic[4]) == 5)
+	{
+		if(ic[4]==0)
+		{
+			printf("found PINHOLE camera model, building rectifier.\n");
+            u = new UndistortPinhole(configFilename, true);
+			if(!u->isValid()) {delete u; return 0; }
+		}
+		else
+		{
+			printf("found FOV camera model, building rectifier.\n");
+            u = new UndistortFOV(configFilename, true);
+			if(!u->isValid()) {delete u; return 0; }
+		}
+	}
+
+
+
+
+
+    // clean model selection implementation.
+    else if(std::sscanf(l1.c_str(), "KannalaBrandt %f %f %f %f %f %f %f %f",
+            &ic[0], &ic[1], &ic[2], &ic[3],
+            &ic[4], &ic[5], &ic[6], &ic[7]) == 8)
+    {
+        u = new UndistortKB(configFilename, false);
+        if(!u->isValid()) {delete u; return 0; }
+    }
+
+
+    else if(std::sscanf(l1.c_str(), "RadTan %f %f %f %f %f %f %f %f",
+            &ic[0], &ic[1], &ic[2], &ic[3],
+            &ic[4], &ic[5], &ic[6], &ic[7]) == 8)
+    {
+        u = new UndistortRadTan(configFilename, false);
+        if(!u->isValid()) {delete u; return 0; }
+    }
+
+
+    else if(std::sscanf(l1.c_str(), "EquiDistant %f %f %f %f %f %f %f %f",
+            &ic[0], &ic[1], &ic[2], &ic[3],
+            &ic[4], &ic[5], &ic[6], &ic[7]) == 8)
+    {
+        u = new UndistortEquidistant(configFilename, false);
+        if(!u->isValid()) {delete u; return 0; }
+    }
+
+
+    else if(std::sscanf(l1.c_str(), "FOV %f %f %f %f %f",
+            &ic[0], &ic[1], &ic[2], &ic[3],
+            &ic[4]) == 5)
+    {
+        u = new UndistortFOV(configFilename, false);
+        if(!u->isValid()) {delete u; return 0; }
+    }
+
+
+    else if(std::sscanf(l1.c_str(), "Pinhole %f %f %f %f %f",
+            &ic[0], &ic[1], &ic[2], &ic[3],
+            &ic[4]) == 5)
+    {
+        u = new UndistortPinhole(configFilename, false);
+        if(!u->isValid()) {delete u; return 0; }
+    }
+
+
+    else
+    {
+        printf("could not read calib file! exit.");
+        exit(1);
+    }
+
+	return u;
+}
+
+
+template<typename T>
+void Undistort::undistort(const T* in_data, float* out_data, int nPixIn, int nPixOut) const
+{
+	if(!valid) return;
+
+	if(nPixIn != wOrg*hOrg)
+	{
+		printf("ERROR: undistort called with wrong input image dismesions (expected %d pixel, got %d pixel)\n",
+				wOrg*hOrg, nPixIn);
+		return;
+	}
+	if(nPixOut != w*h)
+	{
+		printf("ERROR: undistort called with wrong output image dismesions (expected %d pixel, got %d pixel)\n",
+				w*h, nPixOut);
+		return;
+	}
+
+
+	for(int idx = w*h-1;idx>=0;idx--)
+	{
+
+		// get interp. values
+		float xx = remapX[idx];
+		float yy = remapY[idx];
+		
+		if(xx<0)
+			out_data[idx] = 0;
+		else
+		{
+			// get integer and rational parts
+			int xxi = xx;
+			int yyi = yy;
+			xx -= xxi;
+			yy -= yyi;
+			float xxyy = xx*yy;
+
+			// get array base pointer
+			const T* src =  in_data + xxi + yyi * wOrg;
+
+			// interpolate (bilinear)
+			out_data[idx] =  xxyy * src[1+wOrg]
+								+ (yy-xxyy) * src[wOrg]
+								+ (xx-xxyy) * src[1]
+								+ (1-xx-yy+xxyy) * src[0];
+		}
+	}
+
+}
+template void Undistort::undistort<float>(const float* in_data, float* out_data, int nPixIn, int nPixOut) const;
+template void Undistort::undistort<unsigned char>(const unsigned char* in_data, float* out_data, int nPixIn, int nPixOut) const;
+
+
+void Undistort::makeOptimalK_crop()
+{
+	printf("finding CROP optimal new model!\n");
+	K.setIdentity();
+
+	// 1. stretch the center lines as far as possible, to get initial coarse quess.
+	float* tgX = new float[100000];
+	float* tgY = new float[100000];
+	float minX = 0;
+	float maxX = 0;
+	float minY = 0;
+	float maxY = 0;
+
+	for(int x=0; x<100000;x++)
+	{tgX[x] = (x-50000.0f) / 10000.0f; tgY[x] = 0;}
+	distortCoordinates(tgX, tgY,tgX, tgY,100000);
+	for(int x=0; x<100000;x++)
+	{
+		if(tgX[x] > 0 && tgX[x] < wOrg-1)
+		{
+			if(minX==0) minX = (x-50000.0f) / 10000.0f;
+			maxX = (x-50000.0f) / 10000.0f;
+		}
+	}
+	for(int y=0; y<100000;y++)
+	{tgY[y] = (y-50000.0f) / 10000.0f; tgX[y] = 0;}
+	distortCoordinates(tgX, tgY,tgX, tgY,100000);
+	for(int y=0; y<100000;y++)
+	{
+		if(tgY[y] > 0 && tgY[y] < hOrg-1)
+		{
+			if(minY==0) minY = (y-50000.0f) / 10000.0f;
+			maxY = (y-50000.0f) / 10000.0f;
+		}
+	}
+	delete[] tgX;
+	delete[] tgY;
+
+	minX *= 1.01;
+	maxX *= 1.01;
+	minY *= 1.01;
+	maxY *= 1.01;
+
+
+
+	printf("initial range: x: %.4f - %.4f; y: %.4f - %.4f!\n", minX, maxX, minY, maxY);
+
+
+
+	// 2. while there are invalid pixels at the border: shrink square at the side that has invalid pixels,
+	// if several to choose from, shrink the wider dimension.
+	bool oobLeft=true, oobRight=true, oobTop=true, oobBottom=true;
+	int iteration=0;
+	while(oobLeft || oobRight || oobTop || oobBottom)
+	{
+		oobLeft=oobRight=oobTop=oobBottom=false;
+		for(int y=0;y<h;y++)
+		{
+			remapX[y*2] = minX;
+			remapX[y*2+1] = maxX;
+			remapY[y*2] = remapY[y*2+1] = minY + (maxY-minY) * (float)y / ((float)h-1.0f);
+		}
+		distortCoordinates(remapX, remapY,remapX, remapY,2*h);
+		for(int y=0;y<h;y++)
+		{
+			if(!(remapX[2*y] > 0 && remapX[2*y] < wOrg-1))
+				oobLeft = true;
+			if(!(remapX[2*y+1] > 0 && remapX[2*y+1] < wOrg-1))
+				oobRight = true;
+		}
+
+
+
+		for(int x=0;x<w;x++)
+		{
+			remapY[x*2] = minY;
+			remapY[x*2+1] = maxY;
+			remapX[x*2] = remapX[x*2+1] = minX + (maxX-minX) * (float)x / ((float)w-1.0f);
+		}
+		distortCoordinates(remapX, remapY,remapX, remapY,2*w);
+
+
+		for(int x=0;x<w;x++)
+		{
+			if(!(remapY[2*x] > 0 && remapY[2*x] < hOrg-1))
+				oobTop = true;
+			if(!(remapY[2*x+1] > 0 && remapY[2*x+1] < hOrg-1))
+				oobBottom = true;
+		}
+
+
+		if((oobLeft || oobRight) && (oobTop || oobBottom))
+		{
+			if((maxX-minX) > (maxY-minY))
+				oobBottom = oobTop = false;	// only shrink left/right
+			else
+				oobLeft = oobRight = false; // only shrink top/bottom
+		}
+
+		if(oobLeft) minX *= 0.995;
+		if(oobRight) maxX *= 0.995;
+		if(oobTop) minY *= 0.995;
+		if(oobBottom) maxY *= 0.995;
+
+		iteration++;
+
+
+		printf("iteration %05d: range: x: %.4f - %.4f; y: %.4f - %.4f!\n", iteration,  minX, maxX, minY, maxY);
+		if(iteration > 500)
+		{
+			printf("FAILED TO COMPUTE GOOD CAMERA MATRIX - SOMETHING IS SERIOUSLY WRONG. ABORTING \n");
+			exit(1);
+		}
+	}
+
+	K(0,0) = ((float)w-1.0f)/(maxX-minX);
+	K(1,1) = ((float)h-1.0f)/(maxY-minY);
+	K(0,2) = -minX*K(0,0);
+	K(1,2) = -minY*K(1,1);
+
+}
+
+void Undistort::makeOptimalK_full()
+{
+	// todo
+	assert(false);
+}
+
+void Undistort::readFromFile(const char* configFileName, int nPars, std::string prefix)
+{
+	valid = false;
+	passthrough=false;
+	remapX = 0;
+	remapY = 0;
+	
+	float outputCalibration[5];
+
+	parsOrg = VecX(nPars);
+
+	// read parameters
+	std::ifstream infile(configFileName);
+	assert(infile.good());
+
+    std::string l1,l2,l3,l4;
+
+	std::getline(infile,l1);
+	std::getline(infile,l2);
+    std::getline(infile,l3);
+    std::getline(infile,l4);
+
+    // l1 & l2
+    if(nPars == 5) // fov model
+	{
+		char buf[1000];
+		snprintf(buf, 1000, "%s%%f %%f %%f %%f %%f", prefix.c_str());
+		
+		if(std::sscanf(l1.c_str(), buf, &parsOrg[0], &parsOrg[1], &parsOrg[2], &parsOrg[3], &parsOrg[4]) == 5 &&
+				std::sscanf(l2.c_str(), "%d %d", &wOrg, &hOrg) == 2)
+		{
+			printf("Input resolution: %d %d\n",wOrg, hOrg);
+			printf("In: %f %f %f %f %f\n",
+					parsOrg[0], parsOrg[1], parsOrg[2], parsOrg[3], parsOrg[4]);
+		}
+		else
+		{
+			printf("Failed to read camera calibration (invalid format?)\nCalibration file: %s\n", configFileName);
+			infile.close();
+			return;
+		}
+	}
+	else if(nPars == 8) // KB, equi & radtan model
+	{
+		char buf[1000];
+		snprintf(buf, 1000, "%s%%f %%f %%f %%f %%f %%f %%f %%f %%f %%f", prefix.c_str());
+
+		if(std::sscanf(l1.c_str(), buf,
+				&parsOrg[0], &parsOrg[1], &parsOrg[2], &parsOrg[3], &parsOrg[4],
+				&parsOrg[5], &parsOrg[6], &parsOrg[7]) == 8 &&
+				std::sscanf(l2.c_str(), "%d %d", &wOrg, &hOrg) == 2)
+		{
+			printf("Input resolution: %d %d\n",wOrg, hOrg);
+			printf("In: %s%f %f %f %f %f %f %f %f\n",
+					prefix.c_str(),
+					parsOrg[0], parsOrg[1], parsOrg[2], parsOrg[3], parsOrg[4], parsOrg[5], parsOrg[6], parsOrg[7]);
+		}
+		else
+		{
+			printf("Failed to read camera calibration (invalid format?)\nCalibration file: %s\n", configFileName);
+			infile.close();
+			return;
+		}
+	}
+	else
+	{
+		printf("called with invalid number of parameters.... forgot to implement me?\n");
+		infile.close();
+		return;
+	}
+
+
+
+
+    if(parsOrg[2] < 1 && parsOrg[3] < 1)
+    {
+        printf("\n\nFound fx=%f, fy=%f, cx=%f, cy=%f.\n I'm assuming this is the \"relative\" calibration file format,"
+               "and will rescale this by image width / height to fx=%f, fy=%f, cx=%f, cy=%f.\n\n",
+               parsOrg[0], parsOrg[1], parsOrg[2], parsOrg[3],
+               parsOrg[0] * wOrg, parsOrg[1] * hOrg, parsOrg[2] * wOrg - 0.5, parsOrg[3] * hOrg - 0.5 );
+
+        // rescale and substract 0.5 offset.
+        // the 0.5 is because I'm assuming the calibration is given such that the pixel at (0,0)
+        // contains the integral over intensity over [0,0]-[1,1], whereas I assume the pixel (0,0)
+        // to contain a sample of the intensity ot [0,0], which is best approximated by the integral over
+        // [-0.5,-0.5]-[0.5,0.5]. Thus, the shift by -0.5.
+        parsOrg[0] = parsOrg[0] * wOrg;
+        parsOrg[1] = parsOrg[1] * hOrg;
+        parsOrg[2] = parsOrg[2] * wOrg - 0.5;
+        parsOrg[3] = parsOrg[3] * hOrg - 0.5;
+    }
+
+
+
+	// l3
+	if(l3 == "crop")
+	{
+		outputCalibration[0] = -1;
+        printf("Out: Rectify Crop\n");
+	}
+	else if(l3 == "full")
+	{
+		outputCalibration[0] = -2;
+        printf("Out: Rectify Full\n");
+	}
+	else if(l3 == "none")
+	{
+		outputCalibration[0] = -3;
+        printf("Out: No Rectification\n");
+	}
+	else if(std::sscanf(l3.c_str(), "%f %f %f %f %f", &outputCalibration[0], &outputCalibration[1], &outputCalibration[2], &outputCalibration[3], &outputCalibration[4]) == 5)
+	{
+		printf("Out: %f %f %f %f %f\n",
+				outputCalibration[0], outputCalibration[1], outputCalibration[2], outputCalibration[3], outputCalibration[4]);
+
+	}
+	else
+	{
+		printf("Out: Failed to Read Output pars... not rectifying.\n");
+		infile.close();
+		return;
+	}
+	
+
+
+	// l4
+	if(std::sscanf(l4.c_str(), "%d %d", &w, &h) == 2)
+	{
+		if(benchmarkSetting_width != 0)
+        {
+			w = benchmarkSetting_width;
+            if(outputCalibration[0] == -3)
+                outputCalibration[0] = -1;  // crop instead of none, since probably resolution changed.
+        }
+        if(benchmarkSetting_height != 0)
+        {
+			h = benchmarkSetting_height;
+            if(outputCalibration[0] == -3)
+                outputCalibration[0] = -1;  // crop instead of none, since probably resolution changed.
+        }
+
+		printf("Output resolution: %d %d\n",w, h);
+	}
+	else
+	{
+		printf("Out: Failed to Read Output resolution... not rectifying.\n");
+		valid = false;
+    }
+
+    remapX = new float[w*h];
+    remapY = new float[w*h];
+
+	if(outputCalibration[0] == -1)
+		makeOptimalK_crop();
+	else if(outputCalibration[0] == -2)
+		makeOptimalK_full();
+	else if(outputCalibration[0] == -3)
+	{
+		if(w != wOrg || h != hOrg)
+		{
+			printf("ERROR: rectification mode none requires input and output dimenstions to match!\n\n");
+			exit(1);
+		}
+		K.setIdentity();
+        K(0,0) = parsOrg[0];
+        K(1,1) = parsOrg[1];
+        K(0,2) = parsOrg[2];
+        K(1,2) = parsOrg[3];
+		passthrough = true;
+	}
+	else
+	{
+
+
+        if(outputCalibration[2] > 1 || outputCalibration[3] > 1)
+        {
+            printf("\n\n\nWARNING: given output calibration (%f %f %f %f) seems wrong. It needs to be relative to image width / height!\n\n\n",
+                   outputCalibration[0],outputCalibration[1],outputCalibration[2],outputCalibration[3]);
+        }
+
+
+		K.setIdentity();
+        K(0,0) = outputCalibration[0] * w;
+        K(1,1) = outputCalibration[1] * h;
+        K(0,2) = outputCalibration[2] * w - 0.5;
+        K(1,2) = outputCalibration[3] * h - 0.5;
+	}
+
+	if(benchmarkSetting_fxfyfac != 0)
+	{
+		K(0,0) = fmax(benchmarkSetting_fxfyfac, (float)K(0,0));
+		K(1,1) = fmax(benchmarkSetting_fxfyfac, (float)K(1,1));
+        passthrough = false; // cannot pass through when fx / fy have been overwritten.
+	}
+
+
+	for(int y=0;y<h;y++)
+		for(int x=0;x<w;x++)
+		{
+			remapX[x+y*w] = x;
+			remapY[x+y*w] = y;
+		}
+
+	distortCoordinates(remapX, remapY, remapX, remapY, h*w);
+
+
+	for(int y=0;y<h;y++)
+		for(int x=0;x<w;x++)
+		{
+			// make rounding resistant.
+			float ix = remapX[x+y*w];
+			float iy = remapY[x+y*w];
+
+			if(ix == 0) ix = 0.001;
+			if(iy == 0) iy = 0.001;
+			if(ix == wOrg-1) ix = wOrg-1.001;
+			if(iy == hOrg-1) iy = hOrg-1.001;
+
+			if(ix > 0 && iy > 0 && ix < wOrg-1 &&  iy < hOrg-1)
+			{
+				remapX[x+y*w] = ix;
+				remapY[x+y*w] = iy;
+			}
+			else
+			{
+				remapX[x+y*w] = -1;
+				remapY[x+y*w] = -1;
+			}
+		}
+
+	valid = true;
+
+	Korg.setIdentity();
+    Korg(0,0) = parsOrg[0] * wOrg;
+    Korg(1,1) = parsOrg[1] * hOrg;
+    Korg(0,2) = parsOrg[2] * wOrg - 0.5;
+    Korg(1,2) = parsOrg[3] * hOrg - 0.5;
+
+
+	printf("\nRectified Kamera Matrix:\n");
+	std::cout << K << "\n\n";
+
+}
+
+
+UndistortFOV::UndistortFOV(const char* configFileName, bool noprefix)
+{
+    printf("Creating FOV undistorter\n");
+
+    if(noprefix)
+        readFromFile(configFileName, 5);
+    else
+        readFromFile(configFileName, 5, "FOV ");
+}
+UndistortFOV::~UndistortFOV()
+{
+}
+
+void UndistortFOV::distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const
+{
+	float dist = parsOrg[4];
+	float d2t = 2.0f * tan(dist / 2.0f);
+
+
+
+	// current camera parameters
+    float fx = parsOrg[0];
+    float fy = parsOrg[1];
+    float cx = parsOrg[2];
+    float cy = parsOrg[3];
+
+
+
+	float ofx = K(0,0);
+	float ofy = K(1,1);
+	float ocx = K(0,2);
+	float ocy = K(1,2);
+
+	for(int i=0;i<n;i++)
+	{
+		float x = in_x[i];
+		float y = in_y[i];
+		float ix = (x - ocx) / ofx;
+		float iy = (y - ocy) / ofy;
+
+		float r = sqrtf(ix*ix + iy*iy);
+		float fac = (r==0 || dist==0) ? 1 : atanf(r * d2t)/(dist*r);
+
+		ix = fx*fac*ix+cx;
+		iy = fy*fac*iy+cy;
+
+		out_x[i] = ix;
+		out_y[i] = iy;
+	}
+}
+
+
+
+
+
+
+UndistortRadTan::UndistortRadTan(const char* configFileName, bool noprefix)
+{
+    printf("Creating RadTan undistorter\n");
+
+    if(noprefix)
+        readFromFile(configFileName, 8);
+    else
+        readFromFile(configFileName, 8,"RadTan ");
+}
+UndistortRadTan::~UndistortRadTan()
+{
+}
+
+void UndistortRadTan::distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const
+{
+    // RADTAN
+    float fx = parsOrg[0];
+    float fy = parsOrg[1];
+    float cx = parsOrg[2];
+    float cy = parsOrg[3];
+    float k1 = parsOrg[4];
+    float k2 = parsOrg[5];
+    float r1 = parsOrg[6];
+    float r2 = parsOrg[7];
+
+    float ofx = K(0,0);
+    float ofy = K(1,1);
+    float ocx = K(0,2);
+    float ocy = K(1,2);
+
+
+
+    for(int i=0;i<n;i++)
+    {
+        float x = in_x[i];
+        float y = in_y[i];
+
+        // RADTAN
+        float ix = (x - ocx) / ofx;
+        float iy = (y - ocy) / ofy;
+        float mx2_u = ix * ix;
+        float my2_u = iy * iy;
+        float mxy_u = ix * iy;
+        float rho2_u = mx2_u+my2_u;
+        float rad_dist_u = k1 * rho2_u + k2 * rho2_u * rho2_u;
+        float x_dist = ix + ix * rad_dist_u + 2.0 * r1 * mxy_u + r2 * (rho2_u + 2.0 * mx2_u);
+        float y_dist = iy + iy * rad_dist_u + 2.0 * r2 * mxy_u + r1 * (rho2_u + 2.0 * my2_u);
+        float ox = fx*x_dist+cx;
+        float oy = fy*y_dist+cy;
+
+
+        out_x[i] = ox;
+        out_y[i] = oy;
+    }
+
+
+}
+
+
+
+UndistortEquidistant::UndistortEquidistant(const char* configFileName, bool noprefix)
+{
+    printf("Creating Equidistant undistorter\n");
+
+    if(noprefix)
+        readFromFile(configFileName, 8);
+    else
+        readFromFile(configFileName, 8,"EquiDistant ");
+}
+UndistortEquidistant::~UndistortEquidistant()
+{
+}
+
+void UndistortEquidistant::distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const
+{
+    // EQUI
+    float fx = parsOrg[0];
+    float fy = parsOrg[1];
+    float cx = parsOrg[2];
+    float cy = parsOrg[3];
+    float k1 = parsOrg[4];
+    float k2 = parsOrg[5];
+    float k3 = parsOrg[6];
+    float k4 = parsOrg[7];
+
+
+    float ofx = K(0,0);
+    float ofy = K(1,1);
+    float ocx = K(0,2);
+    float ocy = K(1,2);
+
+
+
+    for(int i=0;i<n;i++)
+    {
+        float x = in_x[i];
+        float y = in_y[i];
+
+        // EQUI
+        float ix = (x - ocx) / ofx;
+        float iy = (y - ocy) / ofy;
+        float r = sqrt(ix * ix + iy * iy);
+        float theta = atan(r);
+        float theta2 = theta * theta;
+        float theta4 = theta2 * theta2;
+        float theta6 = theta4 * theta2;
+        float theta8 = theta4 * theta4;
+        float thetad = theta * (1 + k1 * theta2 + k2 * theta4 + k3 * theta6 + k4 * theta8);
+        float scaling = (r > 1e-8) ? thetad / r : 1.0;
+        float ox = fx*ix*scaling + cx;
+        float oy = fy*iy*scaling + cy;
+		
+		out_x[i] = ox;
+		out_y[i] = oy;
+
+    }
+}
+
+
+
+UndistortKB::UndistortKB(const char* configFileName, bool noprefix)
+{
+	printf("Creating KannalaBrandt undistorter\n");
+
+    if(noprefix)
+        readFromFile(configFileName, 8);
+    else
+        readFromFile(configFileName, 8,"KannalaBrandt ");
+}
+UndistortKB::~UndistortKB()
+{
+}
+
+void UndistortKB::distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const
+{
+    const float fx = parsOrg[0];
+	const float fy = parsOrg[1];
+	const float cx = parsOrg[2];
+	const float cy = parsOrg[3];
+    const float k0 = parsOrg[4];
+    const float k1 = parsOrg[5];
+    const float k2 = parsOrg[6];
+    const float k3 = parsOrg[7];
+
+    const float ofx = K(0,0);
+    const float ofy = K(1,1);
+    const float ocx = K(0,2);
+    const float ocy = K(1,2);
+
+
+	for(int i=0;i<n;i++)
+	{
+		float x = in_x[i];
+		float y = in_y[i];
+
+		// RADTAN
+		float ix = (x - ocx) / ofx;
+		float iy = (y - ocy) / ofy;
+
+	    const float Xsq_plus_Ysq = ix*ix + iy*iy;
+	    const float sqrt_Xsq_Ysq = sqrtf(Xsq_plus_Ysq);
+	    const float theta = atan2f( sqrt_Xsq_Ysq, 1 );
+	    const float theta2 = theta*theta;
+	    const float theta3 = theta2*theta;
+	    const float theta5 = theta3*theta2;
+	    const float theta7 = theta5*theta2;
+	    const float theta9 = theta7*theta2;
+	    const float r = theta + k0*theta3 + k1*theta5 + k2*theta7 + k3*theta9;
+
+	    if(sqrt_Xsq_Ysq < 1e-6)
+	    {
+	    	out_x[i] = fx * ix + cx;
+	    	out_y[i] = fy * iy + cy;
+	    }
+	    else
+	    {
+	    	out_x[i] = (r / sqrt_Xsq_Ysq) * fx * ix + cx;
+	    	out_y[i] = (r / sqrt_Xsq_Ysq) * fy * iy + cy;
+	    }
+	}
+}
+
+
+
+
+
+UndistortPinhole::UndistortPinhole(const char* configFileName, bool noprefix)
+{
+    if(noprefix)
+        readFromFile(configFileName, 5);
+    else
+        readFromFile(configFileName, 5,"Pinhole ");
+
+}
+UndistortPinhole::~UndistortPinhole()
+{
+}
+
+void UndistortPinhole::distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const
+{
+	// current camera parameters
+    float fx = parsOrg[0];
+    float fy = parsOrg[1];
+    float cx = parsOrg[2];
+    float cy = parsOrg[3];
+
+	float ofx = K(0,0);
+	float ofy = K(1,1);
+	float ocx = K(0,2);
+	float ocy = K(1,2);
+
+	for(int i=0;i<n;i++)
+	{
+		float x = in_x[i];
+		float y = in_y[i];
+		float ix = (x - ocx) / ofx;
+		float iy = (y - ocy) / ofy;
+		ix = fx*ix+cx;
+		iy = fy*iy+cy;
+		out_x[i] = ix;
+		out_y[i] = iy;
+	}
+}
+

--- a/src/Undistorter.h
+++ b/src/Undistorter.h
@@ -1,0 +1,141 @@
+/**
+* This file is part of DSO.
+* 
+* Copyright 2016 Technical University of Munich and Intel.
+* Developed by Jakob Engel <engelj at in dot tum dot de>,
+* for more information see <http://vision.in.tum.de/dso>.
+* If you use this code, please cite the respective publications as
+* listed on the above website.
+*
+* DSO is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* DSO is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with DSO. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#pragma once
+
+#include "Eigen/Core"
+#include "ExposureImage.h"
+
+typedef Eigen::Matrix3f Mat33;
+typedef Eigen::VectorXf VecX;
+
+
+class Undistort
+{
+public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+	virtual ~Undistort();
+
+	virtual void distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const = 0;
+
+	inline const Mat33 getK() const {return K;};
+	inline Eigen::Matrix3f getK_rect() const {return K;};
+	
+	inline Eigen::Matrix3f getK_org() const	{return Korg;};
+	
+	inline const Eigen::Vector2i getSize() const {return Eigen::Vector2i(w,h);};
+	const Eigen::Vector2i getOutputDims() const {return Eigen::Vector2i(w,h);};
+	
+	inline const VecX getOriginalParameter() const {return parsOrg;};
+	const Eigen::VectorXf getOriginalCalibration() const {return parsOrg;};
+	inline float getOmega() const { return parsOrg[4];}
+	
+	inline const Eigen::Vector2i getOriginalSize() {return Eigen::Vector2i(wOrg,hOrg);};
+	const Eigen::Vector2i getInputDims() const  {return Eigen::Vector2i(wOrg,hOrg);};
+	
+	inline bool isValid() {return valid;};
+
+	template<typename T>
+	void undistort(const T* in_data, float* out_data, int nPixIn, int nPixOut) const;
+	static Undistort* getUndistorterForFile(const char* configFileName);
+	
+	int benchmarkSetting_width = 0;
+	int benchmarkSetting_height = 0;
+	float benchmarkSetting_fxfyfac = 0;
+
+
+protected:
+    int w, h, wOrg, hOrg, wUp, hUp;
+    int upsampleUndistFactor;
+	Mat33 K;
+	Mat33 Korg;
+	VecX parsOrg;
+	bool valid;
+	bool passthrough;
+
+	float* remapX;
+	float* remapY;
+
+	void applyBlurNoise(float* img) const;
+
+	void makeOptimalK_crop();
+	void makeOptimalK_full();
+
+	void readFromFile(const char* configFileName, int nPars, std::string prefix = "");
+};
+
+class UndistortFOV : public Undistort
+{
+public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+
+    UndistortFOV(const char* configFileName, bool noprefix);
+	~UndistortFOV();
+	void distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const;
+
+};
+
+class UndistortRadTan : public Undistort
+{
+public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+    UndistortRadTan(const char* configFileName, bool noprefix);
+    ~UndistortRadTan();
+    void distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const;
+
+};
+
+class UndistortEquidistant : public Undistort
+{
+public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+    UndistortEquidistant(const char* configFileName, bool noprefix);
+    ~UndistortEquidistant();
+    void distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const;
+
+};
+
+class UndistortPinhole : public Undistort
+{
+public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+    UndistortPinhole(const char* configFileName, bool noprefix);
+	~UndistortPinhole();
+	void distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const;
+
+private:
+	float inputCalibration[8];
+};
+
+class UndistortKB : public Undistort
+{
+public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+    UndistortKB(const char* configFileName, bool noprefix);
+	~UndistortKB();
+	void distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const;
+
+};
+
+

--- a/src/main_responseCalib.cpp
+++ b/src/main_responseCalib.cpp
@@ -180,6 +180,7 @@ int main( int argc, char** argv )
 	for(int i=2; i<argc;i++)
 		parseArgument(argv[i]);
 
+	std::string path = std::string(argv[1]);
 
 	// load exposure times & images.
 	// first parameter is dataset location.
@@ -259,18 +260,17 @@ int main( int argc, char** argv )
 	for(int k=0;k<w*h;k++) E[k] = E[k]/En[k];
 
 
-
-	if(-1 == system("rm -rf photoCalibResult")) printf("could not delete old photoCalibResult folder!\n");
-	if(-1 == system("mkdir photoCalibResult")) printf("could not create photoCalibResult folder!\n");
+	if(-1 == system(std::string("rm -rf " + path + "/photoCalibResult").c_str())) printf("could not delete old photoCalibResult folder!\n");
+	if(-1 == system(std::string("mkdir " + path + "/photoCalibResult").c_str())) printf("could not delete old photoCalibResult folder!\n");
 
 
 	std::ofstream logFile;
-	logFile.open("photoCalibResult/log.txt", std::ios::trunc | std::ios::out);
+	logFile.open(path + "/" + "photoCalibResult/log.txt", std::ios::trunc | std::ios::out);
 	logFile.precision(15);
 
 
 	printf("init RMSE = %f! \t", rmse(G, E, exposureVec, dataVec, w*h )[0]);
-	plotE(E,w,h, "photoCalibResult/E-0");
+	plotE(E,w,h, path + "/" + "photoCalibResult/E-0");
 	cv::waitKey(100);
 
 
@@ -307,7 +307,7 @@ int main( int argc, char** argv )
 			printf("optG RMSE = %f! \t", rmse(G, E, exposureVec, dataVec, w*h )[0]);
 
 			char buf[1000]; snprintf(buf, 1000, "photoCalibResult/G-%d.png", it+1);
-			plotG(G, buf);
+			plotG(G, path + "/" + buf);
 		}
 
 
@@ -342,7 +342,7 @@ int main( int argc, char** argv )
 			printf("OptE RMSE = %f!  \t", rmse(G, E, exposureVec, dataVec, w*h )[0]);
 
 			char buf[1000]; snprintf(buf, 1000, "photoCalibResult/E-%d", it+1);
-			plotE(E,w,h, buf);
+			plotE(E,w,h, path + "/" + std::string(buf));
 		}
 
 
@@ -365,7 +365,7 @@ int main( int argc, char** argv )
 	logFile.close();
 
 	std::ofstream lg;
-	lg.open("photoCalibResult/pcalib.txt", std::ios::trunc | std::ios::out);
+	lg.open(path + "/" + "photoCalibResult/pcalib.txt", std::ios::trunc | std::ios::out);
 	lg.precision(15);
 	for(int i=0;i<256;i++)
 		lg << G[i] << " ";


### PR DESCRIPTION
### Main changes:

- The camera models code was copied from the DSO repository and changed to fit in the process.
- The results are saved in the folder of the camera.

### Examples:

**FishEye (EquiDistant) camera.** 
**Sequence:** calib-vignette3 (512x512) [(download)](http://vision.in.tum.de/tumvi/exported/euroc/512_16/dataset-calib-vignette3_512_16.tar) from Calibration Sequences from [https://vision.in.tum.de/data/datasets/visual-inertial-dataset](https://vision.in.tum.de/data/datasets/visual-inertial-dataset)

<img src="https://user-images.githubusercontent.com/23337326/52849815-3cc18a80-3112-11e9-8ab9-43d456429a5f.png" width="300"> <img src="https://user-images.githubusercontent.com/23337326/52849827-4519c580-3112-11e9-8e43-bed943bbc3f8.png" width="300">



**FOV (RadTan) camera.** 
**Sequence:** narrowGamma_vignette [(download)](http://vision.in.tum.de/mono/calib_datasets/calib_narrowGamma_vignette.zip) from Calibration Sequences from [https://vision.cs.tum.edu/data/datasets/mono-dataset](https://vision.cs.tum.edu/data/datasets/mono-dataset)

<img src="https://user-images.githubusercontent.com/23337326/52850266-5911f700-3113-11e9-8c0a-c1125a509105.png" width="300"><img src="https://user-images.githubusercontent.com/23337326/52850283-5f07d800-3113-11e9-82f3-3a9b76885067.png" width="300">
